### PR TITLE
Update github.R

### DIFF
--- a/R/github.R
+++ b/R/github.R
@@ -48,7 +48,7 @@ github_repo <- function(repo) {
   head <- httr::HEAD(url)
 
   if (head$status_code != 200) {
-    stop(simple_repo, " is unavailable")
+    return("unavailable")
   }
 
   return(simple_repo)


### PR DESCRIPTION
if repo is unavailable, it should not stop (as it does not allow us to run it on hundreds of links). Now it returns 'unavailable' which allows it to continue (but it will not return other results).